### PR TITLE
FIx overlapping image at `popular.jsx`

### DIFF
--- a/src/components/Popular/Popular.jsx
+++ b/src/components/Popular/Popular.jsx
@@ -4,7 +4,7 @@ import Item from '../Item/Item';
 
 const Popular = () => {
   return (
-    <div className='popular flex-col items-center gap-[10px] h-[90px]'>
+    <div className='popular flex-col items-center gap-[10px] h-fit'>
       <h1 className='text-[#171717] text-[50px] font-[800] text-center'>Upcoming 11.11 Sale!</h1>
       <hr className='w-full h-[6px] rounded-[10px] bg-[#b91c1c]' />
 


### PR DESCRIPTION
changed `h-[90px]` to `h-fit`

It overlaps because the browser thought the "Upcoming 11.11" area was only 90px tall even though it is not. Changing it to `h-fit` will tell the browser that the height of the "Upcoming 11.11" area should fit all items inside it.